### PR TITLE
Added app-level supervision tree with registry

### DIFF
--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -11,7 +11,7 @@ defmodule PolyPost do
 
     opts = [
       strategy: :one_for_one,
-      name: __MODULE__
+      name: :poly_post
     ]
 
     Supervisor.start_link(children, opts)

--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -1,27 +1,19 @@
 defmodule PolyPost do
-  use Supervisor
+  use Application
 
   # API
 
-  def start_link do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
-  end
-
-  # Callbacks
-
-  def child_spec(_) do
-    %{
-      id: __MODULE__,
-      type: :supervisor,
-      start: {__MODULE__, :start_link, []}
-    }
-  end
-
-  def init(_) do
+  @impl true
+  def start(_type, _args) do
     children = [
       {Registry, [keys: :unique, name: PolyPost.Registry]}
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    opts = [
+      strategy: :one_for_one,
+      name: __MODULE__
+    ]
+
+    Supervisor.start_link(children, opts)
   end
 end

--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -10,8 +10,7 @@ defmodule PolyPost do
     ]
 
     opts = [
-      strategy: :one_for_one,
-      name: __MODULE__
+      strategy: :one_for_one
     ]
 
     Supervisor.start_link(children, opts)

--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -11,7 +11,7 @@ defmodule PolyPost do
 
     opts = [
       strategy: :one_for_one,
-      name: :poly_post
+      name: __MODULE__
     ]
 
     Supervisor.start_link(children, opts)

--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -1,2 +1,27 @@
 defmodule PolyPost do
+  use Supervisor
+
+  # API
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  # Callbacks
+
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      type: :supervisor,
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
+  def init(_) do
+    children = [
+      {Registry, [keys: :unique, name: PolyPost.Registry]}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule PolyPost.MixProject do
 
   def application do
     [
+      mod: {PolyPost, []},
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
## Summary

This registry is used to manage processes that are mapped to each resource.

## Details

Each resource will eventually be tied to registered process that will be linked to an `ets` table.

## Acceptance Criteria

- [x] A registry is supervised by the application at startup