### PR TITLE
Add Depot process to manage content for resources

### DIFF
--- a/lib/poly_post/depot.ex
+++ b/lib/poly_post/depot.ex
@@ -1,0 +1,71 @@
+defmodule PolyPost.Depot do
+  use GenServer
+
+  alias PolyPost.Resource
+
+  @type name :: atom()
+
+  # API
+
+  @spec start_link(name()) :: GenServer.on_start()
+  def start_link(name) do
+    GenServer.start_link(__MODULE__, name, name: via(name))
+  end
+
+  @spec clear(name()) :: :ok
+  def clear(name) do
+    GenServer.call(via(name), :clear)
+  end
+
+  @spec find(name(), Resource.key()) :: Resource.content()
+  def find(name, key) do
+    GenServer.call(via(name), {:find, key})
+  end
+
+  @spec get_all(name()) :: [{Resource.key(), Resource.content()}]
+  def get_all(name) do
+    GenServer.call(via(name), :get_all)
+  end
+
+  @spec insert(name(), Resource.key(), Resource.content()) :: :ok
+  def insert(name, key, content) do
+    GenServer.cast(via(name), {:insert, key, content})
+  end
+
+  # Callbacks
+
+  def init(name) do
+    {:ok, :ets.new(name, [:ordered_set, :protected, :named_table]), {:continue, name}}
+  end
+
+  def handle_call(:clear, _from, table) do
+    :ets.delete_all_objects(table)
+    {:reply, :ok, table}
+  end
+
+  def handle_call({:find, key}, _from, table) do
+    case :ets.lookup(table, key) |> List.first() do
+      {_, resource} -> {:reply, resource, table}
+      _ -> {:reply, nil, table}
+    end
+  end
+
+  def handle_call(:get_all, _from, table) do
+    {:reply, :ets.match(table, :"$1") |> List.flatten(), table}
+  end
+
+  def handle_cast({:insert, key, content}, table) do
+    :ets.insert(table, {key, content})
+    {:noreply, table}
+  end
+
+  def handle_continue(_name, state) do
+    {:noreply, state}
+  end
+
+  # Private
+
+  defp via(name) do
+    {:via, Registry, {PolyPost.Registry, name}}
+  end
+end

--- a/lib/poly_post/depot.ex
+++ b/lib/poly_post/depot.ex
@@ -1,4 +1,8 @@
 defmodule PolyPost.Depot do
+  @moduledoc """
+  A process to manage the content for a resource (articles, etc.).
+  """
+
   use GenServer
 
   alias PolyPost.Resource
@@ -7,26 +11,42 @@ defmodule PolyPost.Depot do
 
   # API
 
+  @doc """
+  Starts the Depot process with a given name to represent the
+  resource.
+  """
   @spec start_link(name()) :: GenServer.on_start()
   def start_link(name) do
     GenServer.start_link(__MODULE__, name, name: via(name))
   end
 
+  @doc """
+  Removes all the content related to the resouce.
+  """
   @spec clear(name()) :: :ok
   def clear(name) do
     GenServer.call(via(name), :clear)
   end
 
+  @doc """
+  Finds specific content by a key for the resource.
+  """
   @spec find(name(), Resource.key()) :: Resource.content()
   def find(name, key) do
     GenServer.call(via(name), {:find, key})
   end
 
+  @doc """
+  Gets all content for a resource.
+  """
   @spec get_all(name()) :: [{Resource.key(), Resource.content()}]
   def get_all(name) do
     GenServer.call(via(name), :get_all)
   end
 
+  @doc """
+  Inserts content for a resource via a key
+  """
   @spec insert(name(), Resource.key(), Resource.content()) :: :ok
   def insert(name, key, content) do
     GenServer.cast(via(name), {:insert, key, content})

--- a/lib/poly_post/resource.ex
+++ b/lib/poly_post/resource.ex
@@ -4,11 +4,14 @@ defmodule PolyPost.Resource do
   """
   @moduledoc since: "0.1.0"
 
+  @type key :: term()
+  @type content :: %{key: key()}
+
   @doc """
   Defines a way to return the desired content from the resource.
 
   This MAY return other keys but MUST have have a key named `key`.
   """
   @doc since: "0.1.0"
-  @callback build(reference :: String.t, metadata :: Keyword.t, body :: String.t) :: %{key: term()}
+  @callback build(reference :: String.t, metadata :: Keyword.t, body :: String.t) :: content()
 end

--- a/test/poly_post/depot_test.exs
+++ b/test/poly_post/depot_test.exs
@@ -1,0 +1,59 @@
+defmodule PolyPost.DepotTest do
+  use ExUnit.Case, async: false
+
+  alias PolyPost.{
+    Depot,
+    Resource
+  }
+
+  defmodule TestArticle do
+    @behaviour Resource
+
+    @enforce_keys [:key, :title, :author, :body]
+    defstruct [:key, :author, :title, :body]
+
+    @impl Resource
+    def build(reference, metadata, body) do
+      %__MODULE__{
+        key: reference,
+        title: get_in(metadata, [:title]),
+        author: get_in(metadata, [:author]),
+        body: body
+      }
+    end
+  end
+
+  @table :test_articles
+
+  setup do
+    start_supervised({Depot, @table})
+
+    {:ok, article: %TestArticle{
+        key: "my_article.md",
+        title: "My Article",
+        author: "Me",
+        body: "This is my article"
+     }}
+  end
+
+  describe ".clear/1, .get_all/1 and .insert/3" do
+    test "clears the table of all values", %{article: article} do
+      Depot.clear(@table)
+      assert 0 = Depot.get_all(@table) |> length()
+
+      Depot.insert(@table, article.key, article)
+      assert 1 = Depot.get_all(@table) |> length()
+    end
+  end
+
+  describe ".find/2" do
+    test "returns nothing for non-existing key in the table" do
+      refute Depot.find(@table, "gobble")
+    end
+
+    test "returns a specific object in the table", %{article: article} do
+      Depot.insert(@table, article.key, article)
+      assert %TestArticle{} = Depot.find(@table, article.key)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements a GenServer for each resource to manage access to built resources through `ets`.

## Details

This is done through a series of methods:

* start_link/1 - starts the depot process for a resource
* clear/1 - clears out any content in the resource's `ets` table
* find/2 - finds content for a specific resource via a key
* get_all/1 - gets all content for a resource
* insert/3 - inserts content for a resource on a key 

## Tests

- [x] Specs
