### PR TITLE
Added builder module to build content

### DIFF
--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -1,6 +1,11 @@
 defmodule PolyPost do
   use Application
 
+  alias PolyPost.{
+    Builder,
+    Depot
+  }
+
   # API
 
   @impl true
@@ -14,5 +19,39 @@ defmodule PolyPost do
     ]
 
     Supervisor.start_link(children, opts)
+  end
+
+  @doc """
+  Builds a list of content for a specific markdown + metadata resource
+  and store it in a `Depot` process.
+  """
+  @spec build_and_store!(Resource.name()) :: :ok
+  def build_and_store!(resource) do
+    resource
+    |> Builder.build!()
+    |> save_content(resource)
+
+    :ok
+  end
+
+  @doc """
+  Builds all the content for each  markdown + metadata resource
+  and store it in a corresponding `Depot` process.
+  """
+  @spec build_and_save_all!() :: :ok
+  def build_and_save_all! do
+    Builder.build_all!() |> Enum.each(fn {resource, content} ->
+      save_content(content, resource)
+    end)
+
+    :ok
+  end
+
+  # Private
+
+  defp save_content(content, resource) do
+    Enum.each(content, fn %{key: key} = data ->
+      Depot.insert(resource, key, data)
+    end)
   end
 end

--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -29,7 +29,7 @@ defmodule PolyPost do
   def build_and_store!(resource) do
     resource
     |> Builder.build!()
-    |> save_content(resource)
+    |> store_content(resource)
 
     :ok
   end
@@ -38,10 +38,10 @@ defmodule PolyPost do
   Builds all the content for each  markdown + metadata resource
   and store it in a corresponding `Depot` process.
   """
-  @spec build_and_save_all!() :: :ok
-  def build_and_save_all! do
+  @spec build_and_store_all!() :: :ok
+  def build_and_store_all! do
     Builder.build_all!() |> Enum.each(fn {resource, content} ->
-      save_content(content, resource)
+      store_content(content, resource)
     end)
 
     :ok
@@ -49,7 +49,7 @@ defmodule PolyPost do
 
   # Private
 
-  defp save_content(content, resource) do
+  defp store_content(content, resource) do
     Enum.each(content, fn %{key: key} = data ->
       Depot.insert(resource, key, data)
     end)

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -38,10 +38,10 @@ defmodule PolyPost.Builder do
     apply(module, :build, [filename, metadata, body])
   end
 
-  def build_via_paths!(module, paths, content \\ [])
-  def build_via_paths!(_module, [], content), do: content
-  def build_via_paths!(module, path, content) when is_binary(path), do: build_via_paths!(module, [path], content)
-  def build_via_paths!(module, [path|paths], content) do
+  defp build_via_paths!(module, paths, content \\ [])
+  defp build_via_paths!(_module, [], content), do: content
+  defp build_via_paths!(module, path, content) when is_binary(path), do: build_via_paths!(module, [path], content)
+  defp build_via_paths!(module, [path|paths], content) do
     new_content = path
     |> Path.wildcard()
     |> Enum.reduce(content, fn filepath, acc -> [build_via_filepath!(module, filepath) | acc] end)
@@ -58,14 +58,14 @@ defmodule PolyPost.Builder do
     {metadata, body}
   end
 
-  def extract_metadata!(raw_metadata) do
+  defp extract_metadata!(raw_metadata) do
     case Jason.decode(raw_metadata) do
       {:ok, metadata} -> metadata
       {:error, error} -> raise error
     end
   end
 
-  def extract_parts!(content) do
+  defp extract_parts!(content) do
     case String.split(content, ["\n---\n", "\r\n---\r\n"], parts: 2) do
       [metadata, content] -> {metadata, content}
       _ -> raise PolyPost.MissingMetadataError, "Missing metadata at beginning of file."

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -1,0 +1,110 @@
+defmodule PolyPost.Builder do
+  alias PolyPost.Depot
+
+  # API
+
+  @spec build!(atom()) :: :ok
+  def build!(resource) do
+    resource
+    |> build_content!()
+    |> save_content(resource)
+
+    :ok
+  end
+
+  @spec build_all!() :: :ok
+  def build_all! do
+    Enum.map(get_config(), fn resource ->
+      build_content!(resource) |> save_content(resource)
+    end)
+
+    :ok
+  end
+
+  @spec build_via_paths!(module(), Path.t | [Path.t]) :: [struct()]
+  def build_via_paths!(module, paths, content \\ [])
+  def build_via_paths!(_module, [], content), do: content
+  def build_via_paths!(module, path, content) when is_binary(path), do: build_via_paths!(module, [path], content)
+  def build_via_paths!(module, [path|paths], content) do
+    new_content = path
+    |> Path.wildcard()
+    |> Enum.reduce(content, fn filepath, acc -> [build_via_filepath!(module, filepath) | acc] end)
+
+    build_via_paths!(module, paths, new_content)
+  end
+
+  @spec build_via_filepath!(module(), Path.t) :: struct()
+  def build_via_filepath!(module, filepath) do
+    filename = Path.basename(filepath)
+    {metadata, body} = extract_content!(filepath)
+    apply(module, :build, [filename, metadata, body])
+  end
+
+  # Private
+
+  defp build_content!(resource) do
+    case get_config(resource) do
+      {module, {:path, paths}} -> build_via_paths!(module, paths)
+      _ -> :ok
+    end
+  end
+
+  defp extract_content!(path) do
+    {raw_metadata, raw_content} = File.read!(path) |> extract_parts!()
+
+    metadata = extract_metadata!(raw_metadata)
+    body = transform_all_content(raw_content)
+
+    {metadata, body}
+  end
+
+  def extract_metadata!(raw_metadata) do
+    case Jason.decode(raw_metadata) do
+      {:ok, metadata} -> metadata
+      {:error, error} -> raise error
+    end
+  end
+
+  def extract_parts!(content) do
+    case String.split(content, ["\n---\n", "\r\n---\r\n"], parts: 2) do
+      [metadata, content] -> {metadata, content}
+      _ -> raise PolyPost.MissingMetadataError, "Missing metadata at beginning of file."
+    end
+  end
+
+  defp get_config do
+    Application.fetch_env!(:poly_post, :resources)
+  end
+
+  defp get_config(resource) do
+    get_config() |> get_in([:content, resource])
+  end
+
+  defp save_content(content, resource) do
+    Enum.each(content, fn %{key: key} = data ->
+      Depot.insert(resource, key, data)
+    end)
+  end
+
+  defp transform_all_content(raw_content) do
+    Earmark.as_html!(raw_content, escape: false, registered_processors: [{"code", &transform_code_content/1}])
+  end
+
+  defp transform_code_content({_tag, attrs, content, _meta} = ast) do
+    attr_list = Enum.flat_map(attrs, fn list -> Tuple.to_list(list) end)
+
+    marker = Makeup.Registry.supported_language_names()
+    |> Enum.find(&(Enum.member?(attr_list, &1)))
+
+    case Makeup.Registry.fetch_lexer_by_name(marker) do
+      {:ok, {lexer, opts}} ->
+        new_content = content
+        |> IO.iodata_to_binary()
+        |> Makeup.highlight_inner_html(lexer: lexer, lexer_options: opts)
+
+        {:replace, ~s(<code class="highlight">#{new_content}</code>)}
+      :error ->
+        ast
+    end
+  end
+end

--- a/lib/poly_post/depot.ex
+++ b/lib/poly_post/depot.ex
@@ -7,15 +7,13 @@ defmodule PolyPost.Depot do
 
   alias PolyPost.Resource
 
-  @type name :: atom()
-
   # API
 
   @doc """
   Starts the Depot process with a given name to represent the
   resource.
   """
-  @spec start_link(name()) :: GenServer.on_start()
+  @spec start_link(Resource.name()) :: GenServer.on_start()
   def start_link(name) do
     GenServer.start_link(__MODULE__, name, name: via(name))
   end
@@ -23,7 +21,7 @@ defmodule PolyPost.Depot do
   @doc """
   Removes all the content related to the resouce.
   """
-  @spec clear(name()) :: :ok
+  @spec clear(Resource.name()) :: :ok
   def clear(name) do
     GenServer.call(via(name), :clear)
   end
@@ -31,7 +29,7 @@ defmodule PolyPost.Depot do
   @doc """
   Finds specific content by a key for the resource.
   """
-  @spec find(name(), Resource.key()) :: Resource.content()
+  @spec find(Resource.name(), Resource.key()) :: Resource.content()
   def find(name, key) do
     GenServer.call(via(name), {:find, key})
   end
@@ -39,7 +37,7 @@ defmodule PolyPost.Depot do
   @doc """
   Gets all content for a resource.
   """
-  @spec get_all(name()) :: [{Resource.key(), Resource.content()}]
+  @spec get_all(Resource.name()) :: [{Resource.key(), Resource.content()}]
   def get_all(name) do
     GenServer.call(via(name), :get_all)
   end
@@ -47,7 +45,7 @@ defmodule PolyPost.Depot do
   @doc """
   Inserts content for a resource via a key
   """
-  @spec insert(name(), Resource.key(), Resource.content()) :: :ok
+  @spec insert(Resource.name(), Resource.key(), Resource.content()) :: :ok
   def insert(name, key, content) do
     GenServer.cast(via(name), {:insert, key, content})
   end

--- a/lib/poly_post/missing_metadata_error.ex
+++ b/lib/poly_post/missing_metadata_error.ex
@@ -1,0 +1,3 @@
+defmodule PolyPost.MissingMetadataError do
+  defexception [:message]
+end

--- a/lib/poly_post/resource.ex
+++ b/lib/poly_post/resource.ex
@@ -4,6 +4,7 @@ defmodule PolyPost.Resource do
   """
   @moduledoc since: "0.1.0"
 
+  @type name :: atom()
   @type key :: term()
   @type content :: %{key: key()}
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,9 @@ defmodule PolyPost.MixProject do
 
   defp deps do
     [
+      {:earmark, "~> 1.4"},
+      {:jason, "~> 1.4"},
+      {:makeup, "~> 1.1"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule PolyPost.MixProject do
       app: :poly_post,
       version: "0.1.0",
       elixir: "~> 1.17",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -25,4 +26,7 @@ defmodule PolyPost.MixProject do
       {:makeup, "~> 1.1"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/fixtures"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "earmark": {:hex, :earmark, "1.4.47", "7e7596b84fe4ebeb8751e14cbaeaf4d7a0237708f2ce43630cfd9065551f94ca", [:mix], [], "hexpm", "3e96bebea2c2d95f3b346a7ff22285bc68a99fbabdad9b655aa9c6be06c698f8"},
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "makeup": {:hex, :makeup, "1.1.2", "9ba8837913bdf757787e71c1581c21f9d2455f4dd04cfca785c70bbfff1a76a3", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cce1566b81fbcbd21eca8ffe808f33b221f9eee2cbc7a1706fc3da9ff18e6cac"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
+}

--- a/test/fixtures/test_article.ex
+++ b/test/fixtures/test_article.ex
@@ -1,0 +1,16 @@
+defmodule TestArticle do
+  @behaviour PolyPost.Resource
+
+  @enforce_keys [:key, :title, :author, :body]
+  defstruct [:key, :author, :title, :body]
+
+  @impl PolyPost.Resource
+  def build(reference, metadata, body) do
+    %__MODULE__{
+      key: reference,
+      title: get_in(metadata, ["title"]),
+      author: get_in(metadata, ["author"]),
+      body: body
+    }
+  end
+end

--- a/test/fixtures/test_articles/my_article1.md
+++ b/test/fixtures/test_articles/my_article1.md
@@ -1,0 +1,8 @@
+{
+  "title": "My Article #1",
+  "author": "Me"
+}
+---
+## My Article 1
+
+This is my first article

--- a/test/fixtures/test_articles/my_article2.md
+++ b/test/fixtures/test_articles/my_article2.md
@@ -1,0 +1,8 @@
+{
+  "title": "My Article #2",
+  "author": "Me"
+}
+---
+## My Article 2
+
+This is my second article

--- a/test/fixtures/test_stories/my_story1.md
+++ b/test/fixtures/test_stories/my_story1.md
@@ -1,0 +1,8 @@
+{
+  "title": "My Story #1",
+  "author": "Me"
+}
+---
+## My Story 1
+
+This is my first story

--- a/test/fixtures/test_stories/my_story2.md
+++ b/test/fixtures/test_stories/my_story2.md
@@ -1,0 +1,8 @@
+{
+  "title": "My Story #2",
+  "author": "Me"
+}
+---
+## My Story 2
+
+This is my second story

--- a/test/fixtures/test_story.ex
+++ b/test/fixtures/test_story.ex
@@ -1,0 +1,16 @@
+defmodule TestStory do
+  @behaviour PolyPost.Resource
+
+  @enforce_keys [:key, :title, :author, :body]
+  defstruct [:key, :author, :title, :body]
+
+  @impl PolyPost.Resource
+  def build(reference, metadata, body) do
+    %__MODULE__{
+      key: reference,
+      title: get_in(metadata, ["title"]),
+      author: get_in(metadata, ["author"]),
+      body: body
+    }
+  end
+end

--- a/test/poly_post/builder_test.exs
+++ b/test/poly_post/builder_test.exs
@@ -1,0 +1,78 @@
+defmodule PolyPost.BuilderTest do
+  use ExUnit.Case, async: false
+
+  alias PolyPost.Builder
+
+  @articles_path "test/fixtures/test_articles/*.md"
+  @stories_path "test/fixtures/test_stories/*.md"
+
+  @article_resource :test_articles
+  @story_resource :test_stories
+
+  @resources [
+    content: [
+      test_articles: {TestArticle, {:path, File.cwd!() |> Path.join(@articles_path)}},
+      test_stories: {TestStory, {:path, File.cwd!() |> Path.join(@stories_path)}},
+    ]
+  ]
+
+  setup_all do
+    Application.put_env(:poly_post, :resources, @resources)
+  end
+
+  describe ".build!/1" do
+    test "it builds a specific resource" do
+      assert [
+        %TestArticle{
+          key: "my_article2.md",
+          title: "My Article #2",
+          author: "Me",
+          body: "<h2>\nMy Article 2</h2>\n<p>\nThis is my second article</p>\n"
+        },
+        %TestArticle{
+          key: "my_article1.md",
+          title: "My Article #1",
+          author: "Me",
+          body: "<h2>\nMy Article 1</h2>\n<p>\nThis is my first article</p>\n"
+        }
+      ] = Builder.build!(@article_resource)
+    end
+  end
+
+  describe ".build_all!/0" do
+    test "it builds all the resources" do
+      assert [
+        {@article_resource, [
+            %TestArticle{
+              key: "my_article2.md",
+              title: "My Article #2",
+              author: "Me",
+              body: "<h2>\nMy Article 2</h2>\n<p>\nThis is my second article</p>\n"
+            },
+            %TestArticle{
+              key: "my_article1.md",
+              title: "My Article #1",
+              author: "Me",
+              body: "<h2>\nMy Article 1</h2>\n<p>\nThis is my first article</p>\n"
+            }
+          ]
+        },
+        {@story_resource, [
+            %TestStory{
+              key: "my_story2.md",
+              title: "My Story #2",
+              author: "Me",
+              body: "<h2>\nMy Story 2</h2>\n<p>\nThis is my second story</p>\n"
+            },
+            %TestStory{
+              key: "my_story1.md",
+              title: "My Story #1",
+              author: "Me",
+              body: "<h2>\nMy Story 1</h2>\n<p>\nThis is my first story</p>\n"
+            }
+          ]
+        }
+      ] = Builder.build_all!()
+    end
+  end
+end

--- a/test/poly_post/depot_test.exs
+++ b/test/poly_post/depot_test.exs
@@ -1,27 +1,7 @@
 defmodule PolyPost.DepotTest do
   use ExUnit.Case, async: false
 
-  alias PolyPost.{
-    Depot,
-    Resource
-  }
-
-  defmodule TestArticle do
-    @behaviour Resource
-
-    @enforce_keys [:key, :title, :author, :body]
-    defstruct [:key, :author, :title, :body]
-
-    @impl Resource
-    def build(reference, metadata, body) do
-      %__MODULE__{
-        key: reference,
-        title: get_in(metadata, [:title]),
-        author: get_in(metadata, [:author]),
-        body: body
-      }
-    end
-  end
+  alias PolyPost.Depot
 
   @table :test_articles
 


### PR DESCRIPTION
## Summary

Provides functions for building content for a specific resource or all resources. Also provides functions to save the content after building it into a specific `PolyPost.Depot` process to be looked up via `ETS`.

## Details

Features:

1. Loading content from multiple markdown files
2. Ability to specify multiple resources via path splatting
3. Metadata is parsed as JSON
4. Added ability to use `makeup` to highlight content within `code` tags

## Testing

- Just ex unit loading fixtures to verify parsing of markdown files work
- Happy path focused
