### PR TITLE
Linking description and package functions to project

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,8 @@ defmodule PolyPost.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      description: description(),
+      package: package(),
       source_url: @source_url,
       homepage_url: @source_url
     ]


### PR DESCRIPTION
## Summary

Add more metadata to project to increase context for those looking at the library.

## Details

Specifically, add the `project` and `description` entries to the `mix.exs` file.

## Acceptance Criteria

- [x] Added `package` details
- [x] Added `description` details