### PR TITLE
Added functions to support clearing of resource content

### DIFF
--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -30,7 +30,7 @@ defmodule PolyPost.Builder do
   defp build_content!(resource) do
     case get_config(resource) do
       {module, {:path, paths}} -> build_via_paths!(module, paths)
-      _ -> :ok
+      _ -> []
     end
   end
 

--- a/lib/poly_post/depot.ex
+++ b/lib/poly_post/depot.ex
@@ -29,6 +29,18 @@ defmodule PolyPost.Depot do
   end
 
   @doc """
+  Checks to see if a depot process for a resource exists.
+  """
+  @doc since: "0.2.0"
+  @spec exists?(Resource.name()) :: boolean()
+  def exists?(name) do
+    case Registry.lookup(PolyPost.Registry, name) do
+      [] -> false
+      _ -> true
+    end
+  end
+
+  @doc """
   Finds specific content by a key for the resource.
   """
   @doc since: "0.1.0"

--- a/lib/poly_post/resource.ex
+++ b/lib/poly_post/resource.ex
@@ -3,8 +3,13 @@ defmodule PolyPost.Resource do
   A behavior used to transform a resource (like a markdown file) into structured content.
   """
 
+  @typedoc "Name of an existing resource"
   @type name :: atom()
+
+  @typedoc "The unique ID for an item belonging to a resource"
   @type key :: term()
+
+  @typedoc "The content belonging to an item (includes `key`)"
   @type content :: %{key: key()}
 
   @doc """

--- a/test/poly_post_test.exs
+++ b/test/poly_post_test.exs
@@ -1,0 +1,68 @@
+defmodule PolyPostTest do
+  use ExUnit.Case, async: false
+
+  alias PolyPost.Depot
+
+  @resource :test_articles
+  @non_existing_resource :test_flights
+
+  @articles_path "test/fixtures/test_articles/*.md"
+
+  @resources [
+    content: [
+      test_articles: {TestArticle, {:path, File.cwd!() |> Path.join(@articles_path)}}
+    ]
+  ]
+
+  setup do
+    start_supervised({Depot, @resource})
+
+    Application.put_env(:poly_post, :resources, @resources)
+  end
+
+  describe ".build_and_store!/1" do
+    test "it builds and stores an existing resource" do
+      assert :ok = PolyPost.build_and_store!(@resource)
+      assert 2 = Depot.get_all(@resource) |> length()
+    end
+
+    test "it does not build or store a non-existing resource" do
+      assert {:error, :not_found} = PolyPost.build_and_store!(@non_existing_resource)
+    end
+  end
+
+  describe ".build_and_store_all!/0" do
+    test "it builds and stores all existing resources" do
+      assert :ok = PolyPost.build_and_store_all!()
+      assert 2 = Depot.get_all(@resource) |> length()
+    end
+  end
+
+  describe ".clear/1" do
+    setup do
+      PolyPost.build_and_store_all!()
+    end
+
+    test "it clears the content from a specific resouce" do
+      assert 2 = Depot.get_all(@resource) |> length()
+      assert :ok = PolyPost.clear(@resource)
+      assert 0 = Depot.get_all(@resource) |> length()
+    end
+
+    test "it does not clear content from a non-existing resouce" do
+      assert {:error, :not_found} = PolyPost.clear(@non_existing_resource)
+    end
+  end
+
+  describe ".clear_all/0" do
+    setup do
+      PolyPost.build_and_store_all!()
+    end
+
+    test "it clears all existing resources" do
+      assert 2 = Depot.get_all(@resource) |> length()
+      assert :ok = PolyPost.clear_all()
+      assert 0 = Depot.get_all(@resource) |> length()
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Added functions, typedocs and changed return types to support clearing of resource content

## Details

* Added typedocs to describe `Resource` types
* Added `PolyPost.clear/1` to clear a specific resource
* Added `PolyPost.clear_all/0` to clear all resources
* Added `PolyPost.Depot.exists?/1` to check if a depot process exists for a given resource
* Added tests for new and existing `PolyPost` functions
* Changed return value types for `PolyPost.build_and_store!/1` to handle error cases

## Acceptance Criteria

- [x] After calling `PolyPost.clear_all/0` any existing content across all resources is emptied
- [x] After calling `PolyPost.clear/1` any existing content for a specific resources is emptied
- [x] After calling `PolyPost.Depot.exists?/1` on a a resource, it will tell if the depot process exists or not
- [x] Added function documentation, tests and typespecs