### PR TITLE
Get content from git when calling polypostbuild and store1 or build and store alll0

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,6 +24,11 @@ jobs:
         elixir-version: '1.17.3'
         otp-version: '27.1'
 
+    - name: Setup test git identity
+      run: |
+        git config user.email "github-ci@totemic.dev"
+        git config user.name "Github CI"
+
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -26,8 +26,8 @@ jobs:
 
     - name: Setup test git identity
       run: |
-        git config user.email "github-ci@totemic.dev"
-        git config user.name "Github CI"
+        git config --global user.email "github-ci@totemic.dev"
+        git config --global user.name "Github CI"
 
     - name: Restore dependencies cache
       uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ A publishing engine with markdown and code highlighting support.
   * `PolyPost.build_and_store!/1`
   * `PolyPost.build_and_store_all!/0`
 
+## Requirements
+
+* Elixir 1.17 or greater
+* Erlang OTP 27 or greater
+* Git
+* A mostly POSIX compatible environment (linux, darwin, bsd, etc.)
+
 ## Installation
 
 Add `poly_post` to your list of dependencies in `mix.exs` and include

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ def deps do
 end
 ```
 
+Then run `mix deps.get` and `mix deps.compile` or just a `mix compile` in your app.
+
+## Configuration
+
 In any of the `config/{config,dev,prod,test}.exs` files you can
 configure the front matter decoder and each resource for your content:
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ A publishing engine with markdown and code highlighting support.
 
 ## Installation
 
-You can add `poly_post` to your list of dependencies in `mix.exs`:
+Add `poly_post` to your list of dependencies in `mix.exs` and include
+any decoders you want to use:
 
 ```elixir
 def deps do
   [
-    {:poly_post, "~> 0.1"}
-    {:jason, "~> 1.4"} # For JSON front matter
-    {:yaml_elixir, "~> 2.11"} # For YAML front matter
-    {:toml, "~> 1.4"} # For TOML front matter
+    {:poly_post, "~> 0.1"},
+    {:jason, "~> 1.4"}, # Optional dependency for JSON front matter
+    {:yaml_elixir, "~> 2.11"}, # Optional dependency for YAML front matter
+    {:toml, "~> 1.4"} # Optoinal dependency for TOML front matter
   ]
 end
 ```

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -56,10 +56,10 @@ defmodule PolyPost.Builder do
 
   defp build_via_git!(module, fm_config, paths, dest, git, github, ref) do
     repo = git || Github.expand_repo(github)
+    git_dir = Path.join(dest, ".git")
 
-    if File.dir?(dest) do
+    if File.dir?(dest) && File.dir?(git_dir) do
       if Git.get_status!(dest) != "" do
-        Git.add!(dest, ".")
         Git.stash!(dest)
       end
     else

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -45,9 +45,9 @@ defmodule PolyPost.Builder do
     fm_config = get_in(opts, [:front_matter]) || get_front_matter_config()
 
     cond do
-      dest and paths and not (git or github) ->
+      dest && paths && not (git || github) ->
         build_via_paths!(module, fm_config, paths)
-      dest and paths and (git or github) ->
+      dest && paths && (git || github) ->
         build_via_git!(module, fm_config, paths, dest, git, github, ref)
       :else ->
         []

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -57,9 +57,11 @@ defmodule PolyPost.Builder do
   defp build_via_git!(module, fm_config, paths, dest, git, github, ref) do
     repo = git || Github.expand_repo(github)
 
-    if File.dir?(dest) and Git.get_status!(dest) != "" do
-      Git.add!(dest, ".")
-      Git.stash!(dest)
+    if File.dir?(dest) do
+      if Git.get_status!(dest) != "" do
+        Git.add!(dest, ".")
+        Git.stash!(dest)
+      end
     else
       File.mkdir_p!(dest)
       Git.clone!(repo, dest)

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -1,9 +1,16 @@
 defmodule PolyPost.Builder do
   @moduledoc """
   A module used for building content from Markdown files (resources).
+
+  When configured to use git or github, this will also retrieve
+  content from the specified forge.
   """
 
   alias PolyPost.Resource
+  alias PolyPost.Scm.{
+    Git,
+    Github
+  }
 
   # API
 
@@ -29,20 +36,39 @@ defmodule PolyPost.Builder do
 
   defp build_content!(resources) do
     opts = get_resources_config(resources)
-    module = Keyword.get(opts, :module)
-    filepaths = Keyword.get(opts, :path)
-    fm_config = Keyword.get(opts, :front_matter) || get_front_matter_config()
+    module = get_in(opts, [:module])
+    paths = get_in(opts, [:path])
+    dest = get_in(opts, [:source, :dest])
+    git = get_in(opts, [:source, :git])
+    github = get_in(opts, [:source, :github])
+    ref = get_in(opts, [:source, :ref])
+    fm_config = get_in(opts, [:front_matter]) || get_front_matter_config()
 
     cond do
-      filepaths -> build_via_paths!(module, fm_config, filepaths)
-      :else -> []
+      dest and paths and not (git or github) ->
+        build_via_paths!(module, fm_config, paths)
+      dest and paths and (git or github) ->
+        build_via_git!(module, fm_config, paths, dest, git, github, ref)
+      :else ->
+        []
     end
   end
 
-  defp build_via_filepath!(module, fm_config, filepath) do
-    filename = Path.basename(filepath)
-    {metadata, body} = extract_content!(filepath, fm_config)
-    apply(module, :build, [filename, metadata, body])
+  defp build_via_git!(module, fm_config, paths, dest, git, github, ref) do
+    repo = git || Github.expand_repo(github)
+
+    if File.dir?(dest) and Git.get_status!(dest) != "" do
+      Git.add!(dest, ".")
+      Git.stash!(dest)
+    else
+      File.mkdir_p!(dest)
+      Git.clone!(repo, dest)
+    end
+
+    Git.checkout!(dest, ref || Git.get_default_branch!(dest))
+    Git.pull!(dest)
+
+    build_via_paths!(module, fm_config, paths)
   end
 
   defp build_via_paths!(module, fm_config, paths, content \\ [])
@@ -56,10 +82,16 @@ defmodule PolyPost.Builder do
       path
       |> Path.wildcard()
       |> Enum.reduce(content, fn filepath, acc ->
-        [build_via_filepath!(module, fm_config, filepath) | acc]
+        [build_via_specific_path!(module, fm_config, filepath) | acc]
       end)
 
     build_via_paths!(module, fm_config, paths, new_content)
+  end
+
+  defp build_via_specific_path!(module, fm_config, filepath) do
+    filename = Path.basename(filepath)
+    {metadata, body} = extract_content!(filepath, fm_config)
+    apply(module, :build, [filename, metadata, body])
   end
 
   defp extract_content!(path, fm_config) do

--- a/lib/poly_post/builder.ex
+++ b/lib/poly_post/builder.ex
@@ -45,7 +45,7 @@ defmodule PolyPost.Builder do
     fm_config = get_in(opts, [:front_matter]) || get_front_matter_config()
 
     cond do
-      dest && paths && not (git || github) ->
+      paths && !(git || github) ->
         build_via_paths!(module, fm_config, paths)
       dest && paths && (git || github) ->
         build_via_git!(module, fm_config, paths, dest, git, github, ref)

--- a/lib/poly_post/scm/git.ex
+++ b/lib/poly_post/scm/git.ex
@@ -8,7 +8,7 @@ defmodule PolyPost.Scm.Git do
   end
 
   def checkout!(path, reference) do
-    File.cd!(path, fn -> run!(["checkout", reference]) end)
+    File.cd!(path, fn -> run!(["checkout", reference, "--quiet"]) end)
   end
 
   def clone!(repo, path) do

--- a/lib/poly_post/scm/git.ex
+++ b/lib/poly_post/scm/git.ex
@@ -1,0 +1,51 @@
+defmodule PolyPost.Scm.Git do
+  @moduledoc false
+
+  # API
+
+  def add!(path, specs) do
+    File.cd!(path, fn -> run!(["add", specs]) end)
+  end
+
+  def checkout!(path, reference) do
+    File.cd!(path, fn -> run!(["checkout", reference]) end)
+  end
+
+  def clone!(repo, path) do
+    run!(["clone", repo, path])
+  end
+
+  def get_default_branch!(path) do
+    File.cd!(path, fn -> run!(["rev-parse", "--abbrev-ref", "origin/HEAD"]) end)
+  end
+
+  def get_status!(path) do
+    File.cd!(path, fn -> run!(["status", "-u", "--porcelain"]) end)
+  end
+
+  def pull!(path) do
+    File.cd!(path, fn -> run!(["pull"]) end)
+  end
+
+  def stash!(path) do
+    File.cd!(path, fn -> run!(["stash"]) end)
+  end
+
+  # Private
+
+  defp run!(args) do
+    try do
+      System.cmd("git", args)
+    catch
+      :error, :enoent ->
+        raise "The git command was not found."
+    else
+      {response, 0} ->
+        response
+      {response, _} when is_binary(response) ->
+        raise "The git command failed with reason: #{response}"
+      _ ->
+        raise "The git command failed with args: #{Enum.join(args, " ")}"
+    end
+  end
+end

--- a/lib/poly_post/scm/github.ex
+++ b/lib/poly_post/scm/github.ex
@@ -1,0 +1,9 @@
+defmodule PolyPost.Scm.Github do
+  @moduledoc false
+
+  # API
+
+  def expand_repo(github) do
+    "https://github.com/#{github}.git"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule PolyPost.MixProject do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/fixtures"]
+  defp elixirc_paths(:test), do: ["lib", "test/fixtures", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   defp package do

--- a/test/fixtures/test_articles/my_article1.html
+++ b/test/fixtures/test_articles/my_article1.html
@@ -1,0 +1,4 @@
+<h2>
+My Article 1</h2>
+<p>
+This is my first article</p>

--- a/test/fixtures/test_articles/my_article2.html
+++ b/test/fixtures/test_articles/my_article2.html
@@ -1,0 +1,5 @@
+<h2>
+My Article 2</h2>
+<p>
+This is my second article</p>
+<pre><code class="highlight"><span class="nc">Enum</span><span class="o">.</span><span class="n">map</span><span class="p" data-group-id="group-1">(</span><span class="p" data-group-id="group-2">[</span><span class="mi">1</span><span class="p">,</span><span class="w"> </span><span class="mi">2</span><span class="p">,</span><span class="w"> </span><span class="mi">3</span><span class="p" data-group-id="group-2">]</span><span class="p">,</span><span class="w"> </span><span class="k" data-group-id="group-3">fn</span><span class="w"> </span><span class="n">x</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">x</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="mi">1</span><span class="w"> </span><span class="k" data-group-id="group-3">end</span><span class="p" data-group-id="group-1">)</span></code></pre>

--- a/test/poly_post/builder_test.exs
+++ b/test/poly_post/builder_test.exs
@@ -2,6 +2,7 @@ defmodule PolyPost.BuilderTest do
   use ExUnit.Case, async: false
   use Mneme
 
+  alias PolyPost.GitTestHelper
   alias PolyPost.Builder
 
   @bad_path "test/fixtures/test_bad/*.md"
@@ -13,6 +14,7 @@ defmodule PolyPost.BuilderTest do
   @article_resource :test_articles
   @bad_resource :test_bad
   @missing_resource :test_missing
+  @repo_resource :test_repo
 
   @resources [
     front_matter: [decoder: {Jason, :decode, keys: :atoms}],
@@ -86,76 +88,110 @@ defmodule PolyPost.BuilderTest do
     end
 
     test "it builds a specific resource" do
+      article_body_1 = File.read!("test/fixtures/test_articles/my_article1.html")
+      article_body_2 = File.read!("test/fixtures/test_articles/my_article2.html")
+
+      assert [
+        %TestArticle{
+          author: "Me",
+          body: ^article_body_2,
+          key: "my_article2.md",
+          title: "My Article #2"
+        },
+        %TestArticle{
+          author: "Me",
+          body: ^article_body_1,
+          key: "my_article1.md",
+          title: "My Article #1"
+        }
+      ] = Builder.build!(@article_resource)
+    end
+
+    test "it builds a specific resource from git" do
+      git_resources = build_repo_resources()
+
+      Application.put_env(:poly_post, :resources, git_resources)
+
       auto_assert [
-                    %TestArticle{
-                      author: "Me",
-                      body: """
-                      <h2>
-                      My Article 2</h2>
-                      <p>
-                      This is my second article</p>
-                      <pre><code class="highlight"><span class="nc">Enum</span><span class="o">.</span><span class="n">map</span><span class="p" data-group-id="group-1">(</span><span class="p" data-group-id="group-2">[</span><span class="mi">1</span><span class="p">,</span><span class="w"> </span><span class="mi">2</span><span class="p">,</span><span class="w"> </span><span class="mi">3</span><span class="p" data-group-id="group-2">]</span><span class="p">,</span><span class="w"> </span><span class="k" data-group-id="group-3">fn</span><span class="w"> </span><span class="n">x</span><span class="w"> </span><span class="o">-&gt;</span><span class="w"> </span><span class="n">x</span><span class="w"> </span><span class="o">+</span><span class="w"> </span><span class="mi">1</span><span class="w"> </span><span class="k" data-group-id="group-3">end</span><span class="p" data-group-id="group-1">)</span></code></pre>
-                      """,
-                      key: "my_article2.md",
-                      title: "My Article #2"
-                    },
-                    %TestArticle{
-                      author: "Me",
-                      body: """
-                      <h2>
-                      My Article 1</h2>
-                      <p>
-                      This is my first article</p>
-                      """,
-                      key: "my_article1.md",
-                      title: "My Article #1"
-                    }
-                  ] <- Builder.build!(@article_resource)
+        %TestArticle{
+          body: "<p>\nThis is test content.</p>\n",
+          key: "git_test_content.md"
+        }
+      ] <- Builder.build!(@repo_resource)
+
+      Application.put_env(:poly_post, :resources, @resources)
     end
   end
 
   describe ".build_all!/0" do
     test "it builds all the resources" do
-      auto_assert [
-                    test_articles: [
-                      %TestArticle{
-                        author: "Me",
-                        body:
-                          "<h2>\nMy Article 2</h2>\n<p>\nThis is my second article</p>\n<pre><code class=\"highlight\"><span class=\"nc\">Enum</span><span class=\"o\">.</span><span class=\"n\">map</span><span class=\"p\" data-group-id=\"group-1\">(</span><span class=\"p\" data-group-id=\"group-2\">[</span><span class=\"mi\">1</span><span class=\"p\">,</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"p\">,</span><span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"p\" data-group-id=\"group-2\">]</span><span class=\"p\">,</span><span class=\"w\"> </span><span class=\"k\" data-group-id=\"group-3\">fn</span><span class=\"w\"> </span><span class=\"n\">x</span><span class=\"w\"> </span><span class=\"o\">-&gt;</span><span class=\"w\"> </span><span class=\"n\">x</span><span class=\"w\"> </span><span class=\"o\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"k\" data-group-id=\"group-3\">end</span><span class=\"p\" data-group-id=\"group-1\">)</span></code></pre>\n",
-                        key: "my_article2.md",
-                        title: "My Article #2"
-                      },
-                      %TestArticle{
-                        author: "Me",
-                        body: "<h2>\nMy Article 1</h2>\n<p>\nThis is my first article</p>\n",
-                        key: "my_article1.md",
-                        title: "My Article #1"
-                      }
-                    ],
-                    test_stories: [
-                      %TestStory{
-                        author: "Me",
-                        body: "<h2>\nMy Story 2</h2>\n<p>\nThis is my second story</p>\n",
-                        key: "my_story2.md",
-                        title: "My Story #2"
-                      },
-                      %TestStory{
-                        author: "Me",
-                        body: "<h2>\nMy Story 1</h2>\n<p>\nThis is my first story</p>\n",
-                        key: "my_story1.md",
-                        title: "My Story #1"
-                      }
-                    ],
-                    test_guides: [
-                      %TestGuide{
-                        author: "Me",
-                        body:
-                          "<h2>\nMy Guide 1</h2>\n<p>\nThis is my first guide</p>\n<pre><code class=\"ruby\">a = Klass.new\na.run!</code></pre>\n",
-                        key: "my_guide1.md",
-                        title: "My Guide #1"
-                      }
-                    ]
-                  ] <- Builder.build_all!()
+      article_body_1 = File.read!("test/fixtures/test_articles/my_article1.html")
+      article_body_2 = File.read!("test/fixtures/test_articles/my_article2.html")
+
+      assert [
+        test_articles: [
+          %TestArticle{
+            author: "Me",
+            body: ^article_body_2,
+            key: "my_article2.md",
+            title: "My Article #2"
+          },
+          %TestArticle{
+            author: "Me",
+            body: ^article_body_1,
+            key: "my_article1.md",
+            title: "My Article #1"
+          }
+        ],
+        test_stories: [
+          %TestStory{
+            author: "Me",
+            body: "<h2>\nMy Story 2</h2>\n<p>\nThis is my second story</p>\n",
+            key: "my_story2.md",
+            title: "My Story #2"
+          },
+          %TestStory{
+            author: "Me",
+            body: "<h2>\nMy Story 1</h2>\n<p>\nThis is my first story</p>\n",
+            key: "my_story1.md",
+            title: "My Story #1"
+          }
+        ],
+        test_guides: [
+          %TestGuide{
+            author: "Me",
+            body:
+            "<h2>\nMy Guide 1</h2>\n<p>\nThis is my first guide</p>\n<pre><code class=\"ruby\">a = Klass.new\na.run!</code></pre>\n",
+            key: "my_guide1.md",
+            title: "My Guide #1"
+          }
+        ]
+      ] = Builder.build_all!()
     end
+  end
+
+  # Private
+
+  defp build_repo_resources do
+    dest = GitTestHelper.random_tmp_dir()
+    path = GitTestHelper.setup_tmp_repo()
+    content = Path.join(path, "*.md")
+
+    GitTestHelper.make_test_commit(path)
+
+    [
+      front_matter: [decoder: {YamlElixir, :read_from_string, []}],
+      content: [
+        test_repo: [
+          module: TestArticle,
+          source: [
+            dest: dest,
+            git: path,
+            ref: "main"
+          ],
+          path: content
+        ]
+      ]
+    ]
   end
 end

--- a/test/poly_post/scm/git_test.exs
+++ b/test/poly_post/scm/git_test.exs
@@ -1,85 +1,171 @@
 defmodule PolyPost.Scm.GitTest do
   use ExUnit.Case, async: false
+  use Mneme
+
+  alias PolyPost.Scm.Git
 
   describe "add!/2" do
     test "adds any files specified as staged when in a git repo" do
-      flunk "TBA"
+      path = setup_tmp_repo()
+
+      System.cmd("touch", [Path.join(path, "file.txt")])
+
+      auto_assert "" <- Git.add!(path, ".")
+      auto_assert "A  file.txt\n" <- Git.get_status!(path)
     end
 
     test "errors when any attempting to add files when not in a git repo" do
-      flunk "TBA"
+      path = random_tmp_dir()
+
+      System.cmd("touch", [Path.join(path, "file.txt")])
+
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.add!(path, ".")
+      end
     end
   end
 
   describe "checkout!/2" do
     test "checkouts a reference in a git repo" do
-      flunk "TBA"
+      path = setup_tmp_repo()
+      make_test_commit(path)
+
+      auto_assert "" <- Git.checkout!(path, "main")
+    end
+
+    test "errors when checkouts a reference that is not in a git repo" do
+      path = setup_tmp_repo()
+
+      assert_raise RuntimeError, "The git command failed with reason: 1", fn ->
+        Git.checkout!(path, "main")
+      end
     end
 
     test "errors when checkouts a reference when not in a git repo" do
-      flunk "TBA"
-    end
+      path = random_tmp_dir()
 
-    test "errors when checkouts a reference when in a git repo that does not exist" do
-      flunk "TBA"
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.checkout!(path, "main")
+      end
     end
   end
 
   describe "clone!/2" do
-    test "clones a git repo into a path" do
-      flunk "TBA"
+    setup do
+      {:ok, source: setup_tmp_repo()}
     end
 
-    test "errors when cloning a git repo onto an existing, non-empty path" do
-      flunk "TBA"
+    test "clones a git repo into a path", %{source: source} do
+      path = random_tmp_dir()
+      auto_assert "" <- Git.clone!(source, path)
     end
 
     test "errors when cloning a git repo that does not exist" do
-      flunk "TBA"
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.clone!(random_string(), System.tmp_dir())
+      end
     end
   end
 
   describe "get_default_branch!/1" do
     test "gets the default branch of a git repo" do
-      flunk "TBA"
+      path = setup_tmp_repo()
+      make_test_commit(path)
+
+      auto_assert "main" <- Git.get_default_branch!(path)
     end
 
     test "errors when getting the default branch in a path that is not a git repo" do
-      flunk "TBA"
+      path = random_tmp_dir()
+
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.get_default_branch!(path)
+      end
     end
   end
 
   describe "get_status!/1" do
     test "gets the status of a git repo" do
-      flunk "TBA"
+      path = setup_tmp_repo()
+      auto_assert "" <- Git.get_status!(path)
     end
 
     test "errors when getting the status of a path that is not a git repo" do
-      flunk "TBA"
+      path = random_tmp_dir()
+
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.get_status!(path)
+      end
     end
   end
 
   describe "pull!/1" do
-    test "pulls the current branch of a git repo" do
-      flunk "TBA"
+    setup do
+      source = setup_tmp_repo()
+      make_test_commit(source)
+
+      {:ok, source: source}
     end
 
-    test "errors when pulling on reference that is not a branch on a git repo" do
-      flunk "TBA"
+    test "pulls the current branch of a git repo", %{source: source} do
+      path = random_tmp_dir()
+      Git.clone!(source, path)
+
+      auto_assert "Already up to date.\n" <- Git.pull!(path)
     end
 
     test "errors when pulling on reference when not on a git repo" do
-      flunk "TBA"
+      path = random_tmp_dir()
+
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.pull!(path)
+      end
     end
   end
 
   describe "stash!/1" do
-    test "stash any changes on a git  repo" do
-      flunk "TBA"
+    test "stash any changes on a git repo" do
+      path = setup_tmp_repo()
+      make_test_commit(path)
+
+      System.cmd("touch", [Path.join(path, "file2.txt")])
+
+      auto_assert "?? file2.txt\n" <- Git.get_status!(path)
+      assert String.starts_with?(Git.stash!(path), "Saved working directory")
+      auto_assert "" <- Git.get_status!(path)
     end
 
     test "errors when stashing when not on a git repo" do
-      flunk "TBA"
+      path = random_tmp_dir()
+
+      assert_raise RuntimeError, "The git command failed with reason: 128", fn ->
+        Git.stash!(path)
+      end
     end
+  end
+
+  # Private
+
+  defp make_test_commit(path) do
+    file = Path.join(path, "file.txt")
+    System.cmd("touch", [file])
+    Git.add!(path, file)
+    File.cd!(path, fn -> System.cmd("git", ["commit", "-m", "\"test\""]) end)
+  end
+
+  defp random_string do
+    :rand.bytes(8) |> Base.encode64(padding: false)
+  end
+
+  defp random_tmp_dir do
+    System.tmp_dir()
+    |> Path.join(random_string())
+    |> tap(fn path -> System.cmd("mkdir", ["-p", path]) end)
+  end
+
+  defp setup_tmp_repo do
+    tap(random_tmp_dir(), fn path ->
+      System.cmd("git", ["init", path, "-b", "main", "--quiet"])
+    end)
   end
 end

--- a/test/poly_post/scm/git_test.exs
+++ b/test/poly_post/scm/git_test.exs
@@ -1,0 +1,85 @@
+defmodule PolyPost.Scm.GitTest do
+  use ExUnit.Case, async: false
+
+  describe "add!/2" do
+    test "adds any files specified as staged when in a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when any attempting to add files when not in a git repo" do
+      flunk "TBA"
+    end
+  end
+
+  describe "checkout!/2" do
+    test "checkouts a reference in a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when checkouts a reference when not in a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when checkouts a reference when in a git repo that does not exist" do
+      flunk "TBA"
+    end
+  end
+
+  describe "clone!/2" do
+    test "clones a git repo into a path" do
+      flunk "TBA"
+    end
+
+    test "errors when cloning a git repo onto an existing, non-empty path" do
+      flunk "TBA"
+    end
+
+    test "errors when cloning a git repo that does not exist" do
+      flunk "TBA"
+    end
+  end
+
+  describe "get_default_branch!/1" do
+    test "gets the default branch of a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when getting the default branch in a path that is not a git repo" do
+      flunk "TBA"
+    end
+  end
+
+  describe "get_status!/1" do
+    test "gets the status of a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when getting the status of a path that is not a git repo" do
+      flunk "TBA"
+    end
+  end
+
+  describe "pull!/1" do
+    test "pulls the current branch of a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when pulling on reference that is not a branch on a git repo" do
+      flunk "TBA"
+    end
+
+    test "errors when pulling on reference when not on a git repo" do
+      flunk "TBA"
+    end
+  end
+
+  describe "stash!/1" do
+    test "stash any changes on a git  repo" do
+      flunk "TBA"
+    end
+
+    test "errors when stashing when not on a git repo" do
+      flunk "TBA"
+    end
+  end
+end

--- a/test/poly_post/scm/github_test.exs
+++ b/test/poly_post/scm/github_test.exs
@@ -1,0 +1,9 @@
+defmodule PolyPost.Scm.GithubTest do
+  use ExUnit.Case, async: false
+
+  describe "expand_repo/1" do
+    test "expands github repo shorcut to full URI" do
+      flunk "TBA"
+    end
+  end
+end

--- a/test/poly_post/scm/github_test.exs
+++ b/test/poly_post/scm/github_test.exs
@@ -1,9 +1,13 @@
 defmodule PolyPost.Scm.GithubTest do
   use ExUnit.Case, async: false
+  use Mneme
+
+  alias PolyPost.Scm.Github
 
   describe "expand_repo/1" do
     test "expands github repo shorcut to full URI" do
-      flunk "TBA"
+      auto_assert "https://github.com/totemic-tools/poly_post.git" <-
+        Github.expand_repo("totemic-tools/poly_post")
     end
   end
 end

--- a/test/support/git_test_content.md
+++ b/test/support/git_test_content.md
@@ -1,0 +1,6 @@
+---
+title: Git Test Content
+author: Me
+---
+
+This is test content.

--- a/test/support/git_test_helper.ex
+++ b/test/support/git_test_helper.ex
@@ -1,0 +1,27 @@
+defmodule PolyPost.GitTestHelper do
+  alias PolyPost.Scm.Git
+
+  def make_test_commit(path) do
+    source = File.cwd!() |> Path.join("test/support/git_test_content.md")
+    System.cmd("cp", [source, path])
+
+    Git.add!(path, ".")
+    File.cd!(path, fn -> System.cmd("git", ["commit", "-m", "\"test\""]) end)
+  end
+
+  def random_string do
+    :rand.bytes(8) |> Base.encode64(padding: false)
+  end
+
+  def random_tmp_dir do
+    System.tmp_dir()
+    |> Path.join(random_string())
+    |> tap(fn path -> System.cmd("mkdir", ["-p", path]) end)
+  end
+
+  def setup_tmp_repo do
+    tap(random_tmp_dir(), fn path ->
+      System.cmd("git", ["init", path, "-b", "main", "--quiet"])
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

Add implementation to checkout content via git

## Details

- Adding more clarity on documentation for decoders and requirements
- Added `PolyPost.Scm.Git` and `Github` modules to handle git operations
- Updated workflow to configure a git user for testing git interactions

## Caveats

This does not provide a mechanism for accessing private git repositories. 
Some documentation on working around this will be provided.

