### PR TITLE
Adding PolyPost.list_resources/0

### DIFF
--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -78,6 +78,7 @@ defmodule PolyPost do
   @doc """
   List all resources and their metadata
   """
+  @doc since: "0.2.0"
   @spec list_resources() :: {:ok, keyword(Resource.config())}
   | {:error, :resources_not_found}
   | {:error, :config_not_found}

--- a/lib/poly_post.ex
+++ b/lib/poly_post.ex
@@ -4,7 +4,9 @@ defmodule PolyPost do
   alias PolyPost.{
     Builder,
     Depots,
-    Depot
+    Depot,
+    Resource,
+    Util
   }
 
   # API
@@ -73,7 +75,27 @@ defmodule PolyPost do
     |> Enum.each(fn {resource, _} -> Depot.clear(resource) end)
   end
 
+  @doc """
+  List all resources and their metadata
+  """
+  @spec list_resources() :: {:ok, keyword(Resource.config())}
+  | {:error, :resources_not_found}
+  | {:error, :config_not_found}
+  def list_resources do
+    case Util.get_config() do
+      {:ok, config} -> get_resources(config)
+      :error -> {:error, :config_not_found}
+    end
+  end
+
   # Private
+
+  defp get_resources(config) do
+    case Keyword.fetch(config, :content) do
+      {:ok, content} -> {:ok, content}
+      :error -> {:error, :content_key_not_found}
+    end
+  end
 
   defp store_content(content, resource) do
     Enum.each(content, fn %{key: key} = data ->

--- a/lib/poly_post/depots.ex
+++ b/lib/poly_post/depots.ex
@@ -1,7 +1,10 @@
 defmodule PolyPost.Depots do
   use Supervisor
 
-  alias PolyPost.Depot
+  alias PolyPost.{
+    Depot,
+    Util
+  }
 
   @doc """
   Starts the Depot supervisor
@@ -28,14 +31,10 @@ defmodule PolyPost.Depots do
   # Private
 
   defp depots do
-    case get_config() do
+    case Util.get_config() do
       {:ok, config} -> get_child_specs(config)
       :error -> []
     end
-  end
-
-  defp get_config do
-    Application.fetch_env(:poly_post, :resources)
   end
 
   defp get_child_specs(config) do

--- a/lib/poly_post/resource.ex
+++ b/lib/poly_post/resource.ex
@@ -9,6 +9,9 @@ defmodule PolyPost.Resource do
   @typedoc "The unique ID for an item belonging to a resource"
   @type key :: term()
 
+  @typedoc "The config for a resource"
+  @type config :: {name(), keyword()}
+
   @typedoc "The content belonging to an item (includes `key`)"
   @type content :: %{key: key()}
 

--- a/lib/poly_post/resource.ex
+++ b/lib/poly_post/resource.ex
@@ -10,7 +10,7 @@ defmodule PolyPost.Resource do
   @type key :: term()
 
   @typedoc "The config for a resource"
-  @type config :: {name(), keyword()}
+  @type config :: keyword()
 
   @typedoc "The content belonging to an item (includes `key`)"
   @type content :: %{key: key()}

--- a/lib/poly_post/util.ex
+++ b/lib/poly_post/util.ex
@@ -1,0 +1,8 @@
+defmodule PolyPost.Util do
+  @moduledoc false
+
+  @spec get_config() :: {:ok, term()} | :error
+  def get_config do
+    Application.fetch_env(:poly_post, :resources)
+  end
+end

--- a/test/poly_post_test.exs
+++ b/test/poly_post_test.exs
@@ -73,12 +73,12 @@ defmodule PolyPostTest do
 
   describe ".list_resources/0" do
     test "it returns the list of configured resources" do
-      auto_assert {:ok,
-                   test_articles: [
-                     module: TestArticle,
-                     path:
-                       "/home/angelo/code/projects/totemic/poly_post/test/fixtures/test_articles/*.md"
-                   ]} <- PolyPost.list_resources()
+      assert {:ok, resources} = PolyPost.list_resources()
+      assert Keyword.has_key?(resources, :test_articles)
+
+      metadata = Keyword.get(resources, :test_articles)
+      assert Keyword.has_key?(metadata, :module)
+      assert Keyword.has_key?(metadata, :path)
     end
   end
 end

--- a/test/poly_post_test.exs
+++ b/test/poly_post_test.exs
@@ -1,5 +1,6 @@
 defmodule PolyPostTest do
   use ExUnit.Case, async: false
+  use Mneme
 
   alias PolyPost.Depot
 
@@ -67,6 +68,17 @@ defmodule PolyPostTest do
       assert 2 = Depot.get_all(@resource) |> length()
       assert :ok = PolyPost.clear_all()
       assert 0 = Depot.get_all(@resource) |> length()
+    end
+  end
+
+  describe ".list_resources/0" do
+    test "it returns the list of configured resources" do
+      auto_assert {:ok,
+                   test_articles: [
+                     module: TestArticle,
+                     path:
+                       "/home/angelo/code/projects/totemic/poly_post/test/fixtures/test_articles/*.md"
+                   ]} <- PolyPost.list_resources()
     end
   end
 end


### PR DESCRIPTION
## Summary

Add a function to list the configured resources and their associated metadata.

## Details

Add `PolyPost.list_resources` to return a list of the resources + any configured metadata.

The format of each item should be:

```elixir
@type keyword(Resource.config())
```

where `Resource.config` is a `keyword` list.

## Acceptance Criteria

- [x] The function returns the list of expected resources
- [x] The function is documented, tested and typespeced